### PR TITLE
Added support for custom paste and copy handlers, reverted previous clipboard logic change

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,50 @@
 
 ## Changes from main repo
 
-1. Applied [#368](https://github.com/nick-keller/react-datasheet-grid/pull/368) to prefer text/plain when pasting.
+### 1. Custom copy/paste handler support
+
+The `<DataSheetGrid>` component now accepts optional `pasteHandler` and `copyHandler` props. These allow you to define custom logic for handling paste and copy events, respectively. If these props are not provided, the component will fall back to its default behavior. Both handlers should be memoized using e.g. `useCallback`.
+- `pasteHandler`: A memoized function that takes a string (the pasted content) and returns a 2D array of strings representing the data to be pasted into the grid.
+- `copyHandler`: A memoized function that takes a 2D array of strings (the data to be copied) writes it to the clipboard.
+
+The handlers only deal with raw text data, and ignore any HTML versions in the clipboard. Setting the handlers will disable HTML support for copy/paste.
+
+With the custom handlers, you can use, e.g., the reliable SheetClip library to handle clipboard operations. Example code:
+
+```jsx
+const handlePaste = useCallback((text) => {
+  const sheetclip = new SheetClip();
+  return sheetclip.parse(text);
+}, []);
+
+const handleCopy = useCallback((cellData) => {
+  const sheetclip = new SheetClip();
+  const output = sheetclip.stringify(cellData);
+  if (navigator?.clipboard?.writeText) {
+    navigator.clipboard.writeText(output);
+  }
+}, []);
+
+return (
+  <DataSheetGrid
+    pasteHandler={handlePaste}
+    copyHandler={handleCopy}
+  />
+);
+```
 
 ## Versioning in this fork
 
 We'll follow the same version number as the main number with `inclus.x` added for each change we make.
+
+## Making a new release
+
+We follow this process to make a new release:
+1. Create a patch, and increase the version number in `package.json`. Make a PR to the `master` branch.
+2. Merge the PR, and fork a new `release/<version>` branch from `master`.
+3. In the `release/<version>` branch, run `npm run build` to create the production build.
+4. Commit the `dist` folder to the `release/<version>` branch.
+5. Push the `release/<version>` branch to GitHub, and make a release from it.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inclus/react-datasheet-grid",
-  "version": "4.11.5-inclus.1",
+  "version": "4.11.5-inclus.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@inclus/react-datasheet-grid",
-      "version": "4.11.5-inclus.1",
+      "version": "4.11.5-inclus.2",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-virtual": "^3.0.0-beta.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inclus/react-datasheet-grid",
-  "version": "4.11.5-inclus.1",
+  "version": "4.11.5-inclus.2",
   "description": "An Excel-like React component to create beautiful spreadsheets.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/DataSheetGrid.tsx
+++ b/src/components/DataSheetGrid.tsx
@@ -88,6 +88,8 @@ export const DataSheetGrid = React.memo(
         rowClassName,
         cellClassName,
         onScroll,
+        pasteHandler,
+        copyHandler,
       }: DataSheetGridProps<T>,
       ref: React.ForwardedRef<DataSheetGridRef>
     ): JSX.Element => {
@@ -624,6 +626,11 @@ export const DataSheetGrid = React.memo(
               }
             }
 
+            if (copyHandler) {
+              copyHandler(copyData)
+              return
+            }
+
             const textPlain = copyData.map((row) => row.join('\t')).join('\n')
             const textHtml = `<table>${copyData
               .map(
@@ -679,7 +686,7 @@ export const DataSheetGrid = React.memo(
             }
           }
         },
-        [activeCell, columns, data, editing, selection]
+        [activeCell, columns, data, editing, selection, copyHandler]
       )
       useDocumentEventListener('copy', onCopy)
 
@@ -863,13 +870,21 @@ export const DataSheetGrid = React.memo(
         (event: ClipboardEvent) => {
           if (activeCell && !editing) {
             let pasteData = [['']]
-            if (event.clipboardData?.types.includes('text/plain')) {
-              pasteData = parseTextPlainData(
-                event.clipboardData?.getData('text/plain')
-              )
+            if (pasteHandler) {
+              let pasteString = '';
+              if (event.clipboardData?.types.includes('text/plain')) {
+                pasteString = event.clipboardData?.getData('text/plain')
+              } else if (event.clipboardData?.types.includes('text')) {
+                pasteString = event.clipboardData?.getData('text')
+              }
+              pasteData = pasteHandler(pasteString)
             } else if (event.clipboardData?.types.includes('text/html')) {
               pasteData = parseTextHtmlData(
                 event.clipboardData?.getData('text/html')
+              )
+            } else if (event.clipboardData?.types.includes('text/plain')) {
+              pasteData = parseTextPlainData(
+                event.clipboardData?.getData('text/plain')
               )
             } else if (event.clipboardData?.types.includes('text')) {
               pasteData = parseTextPlainData(
@@ -880,7 +895,7 @@ export const DataSheetGrid = React.memo(
             event.preventDefault()
           }
         },
-        [activeCell, applyPasteDataToDatasheet, editing]
+        [activeCell, applyPasteDataToDatasheet, editing, pasteHandler]
       )
 
       useDocumentEventListener('paste', onPaste)
@@ -1560,16 +1575,22 @@ export const DataSheetGrid = React.memo(
             {
               type: 'PASTE',
               action: async (): Promise<void> => {
-                if (navigator.clipboard.read !== undefined) {
+                if (pasteHandler) {
+                  // PasteHandler always uses the readText method
+                  if (navigator.clipboard.readText !== undefined) {
+                    const text = await navigator.clipboard.readText()
+                    pasteHandler(text)
+                  }
+                } else if (navigator.clipboard.read !== undefined) {
                   const items = await navigator.clipboard.read()
                   items.forEach(async (item) => {
                     let pasteData = [['']]
-                    if (item.types.includes('text/plain')) {
-                      const plainTextData = await item.getType('text/plain')
-                      pasteData = parseTextPlainData(await plainTextData.text())
-                    } else if (item.types.includes('text/html')) {
+                    if (item.types.includes('text/html')) {
                       const htmlTextData = await item.getType('text/html')
                       pasteData = parseTextHtmlData(await htmlTextData.text())
+                    } else if (item.types.includes('text/plain')) {
+                      const plainTextData = await item.getType('text/plain')
+                      pasteData = parseTextPlainData(await plainTextData.text())
                     } else if (item.types.includes('text')) {
                       const htmlTextData = await item.getType('text')
                       pasteData = parseTextHtmlData(await htmlTextData.text())
@@ -1667,6 +1688,7 @@ export const DataSheetGrid = React.memo(
         onCut,
         onCopy,
         applyPasteDataToDatasheet,
+        pasteHandler,
       ])
 
       const contextMenuItemsRef = useRef(contextMenuItems)

--- a/src/components/DataSheetGrid.tsx
+++ b/src/components/DataSheetGrid.tsx
@@ -626,6 +626,8 @@ export const DataSheetGrid = React.memo(
               }
             }
 
+            // If a copyHandler is set, we use it and bypass the rest of the logic.
+            // The copyHandler should take care of writing the data to the clipboard.
             if (copyHandler) {
               copyHandler(copyData)
               return
@@ -870,6 +872,8 @@ export const DataSheetGrid = React.memo(
         (event: ClipboardEvent) => {
           if (activeCell && !editing) {
             let pasteData = [['']]
+            // If pasteHandler is set, we'll only read raw text data
+            // and completely bypass the built-in parsing logic
             if (pasteHandler) {
               let pasteString = '';
               if (event.clipboardData?.types.includes('text/plain')) {
@@ -1575,6 +1579,8 @@ export const DataSheetGrid = React.memo(
             {
               type: 'PASTE',
               action: async (): Promise<void> => {
+                // If pasteHandler is set, we'll only read raw text data
+                // and completely bypass the built-in parsing logic
                 if (pasteHandler) {
                   // PasteHandler always uses the readText method
                   if (navigator.clipboard.readText !== undefined) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,6 +157,8 @@ export type DataSheetGridProps<T> = {
   onActiveCellChange?: (opts: { cell: CellWithId | null }) => void
   onSelectionChange?: (opts: { selection: SelectionWithId | null }) => void
   onScroll?: React.UIEventHandler<HTMLDivElement> | undefined
+  pasteHandler?: (data: string) => string[][]
+  copyHandler?: (data: Array<Array<number | string | null>>) => string
 }
 
 type CellWithIdInput = {


### PR DESCRIPTION
See the README.md file for a detailed explanation. This code functionally matches what is published as a pre-release in https://github.com/incluscom/react-datasheet-grid/releases/tag/v4.11.5-inclus.2 – this PR simply has more documentation. I will redo the release after this branch has been merged.